### PR TITLE
chatgptへのリクエストをパッケージを使わないようにリファクタ

### DIFF
--- a/chatgpt_utils.py
+++ b/chatgpt_utils.py
@@ -31,7 +31,7 @@ def generate_reply_text(text):
         return reply
 
 @retry(
-    stop_max_attempt_number=1,
+    stop_max_attempt_number=3,
     wait_fixed=500, # リトライ間隔
     wrap_exception=True,
 )

--- a/chatgpt_utils.py
+++ b/chatgpt_utils.py
@@ -24,6 +24,7 @@ def generate_reply_text(text):
         logger.logger.error(e)
         text = e.last_attempt.get()
         # リトライ上限までリトライして文字数で引っかかってる場合は切り詰める
+        # エラーの場合は `raise` のワードが出るはずなのでそれで判断する
         reply = truncated_text(text) if not 'raise' in text else reply_on_error
         return reply
     except Exception as e:
@@ -66,5 +67,4 @@ def send_chat(text):
 
 if __name__ == "__main__":
     text = ""
-    print("=== result ===")
-    print(generate_reply_text(text))
+    logger.logger.info(generate_reply_text(text))

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,4 +1,3 @@
-
 max_length = 137
 def truncated_text(text: str):
     return text[:max_length] + "文字数"

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,0 +1,4 @@
+
+max_length = 137
+def truncated_text(text: str):
+    return text[:max_length] + "文字数"


### PR DESCRIPTION
## なぜやるのか
- chatGPTはたまにレスポンスに1分以上かかるときがある
  - 内容次第なので発生はランダム
- chatGPTへのリクエストは `openai` packageを使っていた
- タイムアウトも指定していた
  - でもなぜかタイムアウトが適切に動いてなかった
- これを解決したい

## やったこと
- chatGPTへのリクエストを`openai` packageではなく`requests` packageで書き直した
  - この部分の挙動は変えてない
- chatGPTからの返事が140字を超えているときにリトライしていたが、3回とも文字数超えたらエラーになる状態だった
  - なので1回目から文字数切り詰めて返すようにした